### PR TITLE
Add PTYN parsing and display

### DIFF
--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -145,10 +145,11 @@ const callbacks = {
     dataToSend.rt_flag = flag;
   }, 'callback_rt*'),
 
-  ptyn: koffi.register((rds, flag) => (
-    value = decode_unicode(rdsparser.get_ptyn(rds))
+  ptyn: koffi.register((rds, flag) => {
+    value = decode_unicode(rdsparser.get_ptyn(rds));
+    dataToSend.ptyn = value;
     /*console.log('PTYN: ' + value)*/
-  ), 'callback_ptyn*'),
+  }, 'callback_ptyn*'),
 
   ct: koffi.register((rds, ct) => (
     year = rdsparser.ct_get_year(ct),
@@ -222,6 +223,7 @@ var dataToSend = {
   ta: 0,
   ms: -1,
   pty: 0,
+  ptyn: '',
   ecc: null,
   af: [],
   rt0: '',

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -412,12 +412,14 @@ function handleData(wss, receivedData, rdsWss) {
 
         const blockB = parseInt(modifiedData.slice(4, 8), 16);
         const groupType = (blockB >> 12) & 0xf;
-        if (groupType === 0) {
+        const versionCode = (blockB >> 11) & 0x1;
+        if (groupType === 0 && versionCode === 0) {
           const diValue = (blockB >> 2) & 0x1;
           const diIndex = blockB & 0x3;
 
           switch (diIndex) {
             case 0:
+              // DI bit 0: 0 = stereo, 1 = mono
               dataToSend.rds_di.stereo = diValue === 0;
               break;
             case 1:

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -287,6 +287,12 @@ function rdsReceived() {
 function rdsReset() {
   resetToDefault(dataToSend);
   dataToSend.af.length = 0;
+  dataToSend.rds_di = {
+    stereo: null,
+    compressed: null,
+    artificial_head: null,
+    dynamic_pty: null,
+  };
   rdsparser.clear(rds);
   if (rdsTimeoutTimer) {
     clearTimeout(rdsTimeoutTimer);
@@ -413,7 +419,7 @@ function handleData(wss, receivedData, rdsWss) {
         const blockB = parseInt(modifiedData.slice(4, 8), 16);
         const groupType = (blockB >> 12) & 0xf;
         const versionCode = (blockB >> 11) & 0x1;
-        if (groupType === 0 && versionCode === 0) {
+        if (groupType === 0 && (versionCode === 0 || versionCode === 1)) {
           const diValue = (blockB >> 2) & 0x1;
           const diIndex = blockB & 0x3;
 

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -434,8 +434,8 @@ function handleData(wss, receivedData, rdsWss) {
               dataToSend.rds_di.artificial_head = diValue === 1;
               break;
             case 3:
-              // DI bit 3: 0 = stereo, 1 = mono
-              dataToSend.rds_di.stereo = diValue === 0;
+              // DI bit 3: 1 = stereo, 0 = mono
+              dataToSend.rds_di.stereo = diValue === 1;
               break;
           }
         }

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -419,17 +419,17 @@ function handleData(wss, receivedData, rdsWss) {
 
           switch (diIndex) {
             case 0:
-              // DI bit 0: 0 = stereo, 1 = mono
-              dataToSend.rds_di.stereo = diValue === 0;
+              dataToSend.rds_di.dynamic_pty = diValue === 1;
               break;
             case 1:
-              dataToSend.rds_di.artificial_head = diValue === 1;
-              break;
-            case 2:
               dataToSend.rds_di.compressed = diValue === 1;
               break;
+            case 2:
+              dataToSend.rds_di.artificial_head = diValue === 1;
+              break;
             case 3:
-              dataToSend.rds_di.dynamic_pty = diValue === 1;
+              // DI bit 3: 0 = stereo, 1 = mono
+              dataToSend.rds_di.stereo = diValue === 0;
               break;
           }
         }

--- a/web/css/breadcrumbs.css
+++ b/web/css/breadcrumbs.css
@@ -182,6 +182,10 @@ table .form-group {
     display: none;
 }
 
+#di-container-phone {
+    display: none;
+}
+
 #login-form {
     padding: 5px;
 }
@@ -214,12 +218,16 @@ h3.settings-heading {
 }
 
 #flags-container-phone,
-#flags-container-desktop {
+#flags-container-desktop,
+#di-container-phone,
+#di-container-desktop {
     position: relative; /* Confine overlay within container which is necessary for iPhones */
 }
 
 #flags-container-phone .overlay,
-#flags-container-desktop .overlay {
+#flags-container-desktop .overlay,
+#di-container-phone .overlay,
+#di-container-desktop .overlay {
     position: absolute;
     top: 0;
     left: 0;
@@ -377,6 +385,12 @@ pre {
         display: none;
     }
     #flags-container-phone {
+        display: block;
+    }
+    #di-container-desktop {
+        display: none;
+    }
+    #di-container-phone {
         display: block;
     }
     #tune-buttons {

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -177,6 +177,10 @@
                   <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
+                <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
+                <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+                <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+                <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
               </h3>
             </div>
           </div>
@@ -336,6 +340,10 @@
             <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
+          <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
+          <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+          <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+          <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
         </h3>
       </div>
     </div>

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -179,6 +179,14 @@
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
               </h3>
             </div>
+            <div id="di-container-desktop" class="panel-33 user-select-none">
+              <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+                <span class="data-di-stereo">ST</span>
+                <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+                <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+                <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+              </h3>
+            </div>
           </div>
 
           <div class="flex-container">
@@ -336,6 +344,14 @@
             <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
+        </h3>
+      </div>
+      <div id="di-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
+        <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+          <span class="data-di-stereo">ST</span>
+          <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+          <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+          <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
         </h3>
       </div>
     </div>

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -161,7 +161,7 @@
               <div id="flags-container-desktop" class="panel-33 user-select-none">
               <h2 class="show-phone">
                 <div class="data-pty color-4"></div>
-                <div class="data-ptyn color-4"></div>
+                <div class="data-ptyn color-4" style="display:none;"></div>
               </h2>
               <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
                 <span class="data-tp">TP</span>
@@ -177,33 +177,13 @@
                   <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
-
-
-                <!-- <span style="margin-left: 15px;" class="data-ms">MS</span>
-                <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
+              </h3>
+              <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
+                <span class="data-di-stereo">ST</span>
                 <span style="margin-left: 15px;" class="data-di-ah">AH</span>
                 <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                <span style="margin-left: 15px;" class="data-di-dpty">DP</span> -->
+                <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
               </h3>
-                            <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
-
-                                                <span class="data-di-stereo">ST</span>
-                  <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-                  <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                  <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-                            </h3>
-              
-            </div>
-            </div>
-
-            <div class="flex-container">
-              <div id="di-container-desktop" class="panel-33 user-select-none">
-                <!-- <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
-                  <span class="data-di-stereo">ST</span>
-                  <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-                  <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                  <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-                </h3> -->
               </div>
             </div>
 
@@ -346,7 +326,7 @@
       <div id="flags-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
         <h2 class="show-phone">
           <div class="data-pty color-4"></div>
-          <div class="data-ptyn color-4"></div>
+          <div class="data-ptyn color-4" style="display:none;"></div>
         </h2>
         <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
           <span class="data-tp">TP</span>
@@ -362,29 +342,13 @@
             <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
-          <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
-          <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-          <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-          <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
         </h3>
-      </div>
-      <div id="di-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
-        <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+        <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
           <span class="data-di-stereo">ST</span>
           <span style="margin-left: 15px;" class="data-di-ah">AH</span>
           <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
           <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
         </h3>
-      </div>
-      <div class="flex-container">
-        <div id="di-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
-          <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
-            <span class="data-di-stereo">ST</span>
-            <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-            <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-            <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-          </h3>
-        </div>
       </div>
     </div>
 

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -177,30 +177,33 @@
                   <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
+
+
+                <!-- <span style="margin-left: 15px;" class="data-ms">MS</span>
                 <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
                 <span style="margin-left: 15px;" class="data-di-ah">AH</span>
                 <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+                <span style="margin-left: 15px;" class="data-di-dpty">DP</span> -->
               </h3>
+                            <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+
+                                                <span class="data-di-stereo">ST</span>
+                  <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+                  <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+                  <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+                            </h3>
+              
             </div>
-            <div id="di-container-desktop" class="panel-33 user-select-none">
-              <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
-                <span class="data-di-stereo">ST</span>
-                <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-                <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-              </h3>
-              </div>
             </div>
 
             <div class="flex-container">
               <div id="di-container-desktop" class="panel-33 user-select-none">
-                <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+                <!-- <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
                   <span class="data-di-stereo">ST</span>
                   <span style="margin-left: 15px;" class="data-di-ah">AH</span>
                   <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
                   <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-                </h3>
+                </h3> -->
               </div>
             </div>
 

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -177,33 +177,18 @@
                   <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
-
-
-                <!-- <span style="margin-left: 15px;" class="data-ms">MS</span>
-                <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
-                <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-                <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                <span style="margin-left: 15px;" class="data-di-dpty">DP</span> -->
               </h3>
-                            <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
-
-                                                <span class="data-di-stereo">ST</span>
-                  <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-                  <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                  <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-                            </h3>
-              
-            </div>
+              </div>
             </div>
 
             <div class="flex-container">
               <div id="di-container-desktop" class="panel-33 user-select-none">
-                <!-- <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+                <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
                   <span class="data-di-stereo">ST</span>
                   <span style="margin-left: 15px;" class="data-di-ah">AH</span>
                   <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
                   <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-                </h3> -->
+                </h3>
               </div>
             </div>
 
@@ -362,18 +347,6 @@
             <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
-          <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
-          <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-          <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-          <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-        </h3>
-      </div>
-      <div id="di-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
-        <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
-          <span class="data-di-stereo">ST</span>
-          <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-          <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-          <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
         </h3>
       </div>
       <div class="flex-container">

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -158,7 +158,7 @@
               </div>
             </div>
 
-            <div id="flags-container-desktop" class="panel-33 user-select-none">
+              <div id="flags-container-desktop" class="panel-33 user-select-none">
               <h2 class="show-phone">
                 <div class="data-pty color-4"></div>
                 <div class="data-ptyn color-4"></div>
@@ -178,10 +178,21 @@
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
               </h3>
+              </div>
             </div>
-          </div>
 
-          <div class="flex-container">
+            <div class="flex-container">
+              <div id="di-container-desktop" class="panel-33 user-select-none">
+                <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+                  <span class="data-di-stereo">ST</span>
+                  <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+                  <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+                  <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+                </h3>
+              </div>
+            </div>
+
+            <div class="flex-container">
             <div class="panel-33 hover-brighten tooltip no-bg-phone" id="pi-code-container" data-tooltip="Clicking on the PI code will show the current station on a map.">
               <h2 class="signal-heading">PI CODE</h2>
               <div class="text-small text-gray highest-signal-container">
@@ -337,6 +348,16 @@
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
         </h3>
+      </div>
+      <div class="flex-container">
+        <div id="di-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
+          <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+            <span class="data-di-stereo">ST</span>
+            <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+            <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+            <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+          </h3>
+        </div>
       </div>
     </div>
 

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -161,6 +161,7 @@
             <div id="flags-container-desktop" class="panel-33 user-select-none">
               <h2 class="show-phone">
                 <div class="data-pty color-4"></div>
+                <div class="data-ptyn color-4"></div>
               </h2>
               <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
                 <span class="data-tp">TP</span>
@@ -319,6 +320,7 @@
       <div id="flags-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
         <h2 class="show-phone">
           <div class="data-pty color-4"></div>
+          <div class="data-ptyn color-4"></div>
         </h2>
         <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
           <span class="data-tp">TP</span>

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -179,10 +179,10 @@
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
               </h3>
               <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
-                <span class="data-di-stereo">ST</span>
-                <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-                <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+                <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono">ST</span>
+                <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal">AH</span>
+                <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed">CO</span>
+                <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static">DP</span>
               </h3>
               </div>
             </div>
@@ -344,10 +344,10 @@
           <span style="margin-left: 15px;" class="data-ms">MS</span>
         </h3>
         <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
-          <span class="data-di-stereo">ST</span>
-          <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-          <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-          <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+          <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono">ST</span>
+          <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal">AH</span>
+          <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed">CO</span>
+          <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static">DP</span>
         </h3>
       </div>
     </div>

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -179,10 +179,10 @@
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
               </h3>
               <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
-                <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono">ST</span>
-                <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal">AH</span>
-                <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed">CO</span>
-                <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static">DP</span>
+                <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono"><span class="opacity-half">ST</span></span>
+                <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal"><span class="opacity-half">AH</span></span>
+                <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed"><span class="opacity-half">CO</span></span>
+                <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static"><span class="opacity-half">DP</span></span>
               </h3>
               </div>
             </div>
@@ -344,10 +344,10 @@
           <span style="margin-left: 15px;" class="data-ms">MS</span>
         </h3>
         <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
-          <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono">ST</span>
-          <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal">AH</span>
-          <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed">CO</span>
-          <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static">DP</span>
+          <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono"><span class="opacity-half">ST</span></span>
+          <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal"><span class="opacity-half">AH</span></span>
+          <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed"><span class="opacity-half">CO</span></span>
+          <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static"><span class="opacity-half">DP</span></span>
         </h3>
       </div>
     </div>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -888,6 +888,10 @@ const $dataStationContainer = $('#data-station-container');
 const $dataTp = $('.data-tp');
 const $dataTa = $('.data-ta');
 const $dataMs = $('.data-ms');
+const $dataDiStereo = $('.data-di-stereo');
+const $dataDiAh = $('.data-di-ah');
+const $dataDiCompressed = $('.data-di-compressed');
+const $dataDiDpty = $('.data-di-dpty');
 const $flagDesktopCointainer = $('#flags-container-desktop');
 const $dataPty = $('.data-pty');
 const $dataPtyn = $('.data-ptyn');
@@ -1043,6 +1047,18 @@ const updateDataElements = throttle(function(parsedData) {
                 : "<span class='opacity-full'>M</span><span class='opacity-half'>S</span>"
             )
         );
+        $dataDiStereo.html(parsedData.rds_di && parsedData.rds_di.stereo
+            ? 'ST'
+            : "<span class='opacity-half'>ST</span>");
+        $dataDiAh.html(parsedData.rds_di && parsedData.rds_di.artificial_head
+            ? 'AH'
+            : "<span class='opacity-half'>AH</span>");
+        $dataDiCompressed.html(parsedData.rds_di && parsedData.rds_di.compressed
+            ? 'CO'
+            : "<span class='opacity-half'>CO</span>");
+        $dataDiDpty.html(parsedData.rds_di && parsedData.rds_di.dynamic_pty
+            ? 'DP'
+            : "<span class='opacity-half'>DP</span>");
     }
     
     if (updateCounter % 30 === 0) {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1054,18 +1054,21 @@ const updateDataElements = throttle(function(parsedData) {
                 : "<span class='opacity-full'>M</span><span class='opacity-half'>S</span>"
             )
         );
-        $dataDiStereo.html(parsedData.rds_di && parsedData.rds_di.stereo
-            ? 'ST'
-            : "<span class='opacity-half'>ST</span>");
-        $dataDiAh.html(parsedData.rds_di && parsedData.rds_di.artificial_head
-            ? 'AH'
-            : "<span class='opacity-half'>AH</span>");
-        $dataDiCompressed.html(parsedData.rds_di && parsedData.rds_di.compressed
-            ? 'CO'
-            : "<span class='opacity-half'>CO</span>");
-        $dataDiDpty.html(parsedData.rds_di && parsedData.rds_di.dynamic_pty
-            ? 'DP'
-            : "<span class='opacity-half'>DP</span>");
+        const stereo = parsedData.rds_di ? parsedData.rds_di.stereo : null;
+        $dataDiStereo.html(stereo ? 'ST' : "<span class='opacity-half'>ST</span>")
+            .attr('aria-label', `DI bit 3: ${stereo === null ? 'unknown' : (stereo ? 'stereo' : 'mono')}`);
+
+        const ah = parsedData.rds_di ? parsedData.rds_di.artificial_head : null;
+        $dataDiAh.html(ah ? 'AH' : "<span class='opacity-half'>AH</span>")
+            .attr('aria-label', `DI bit 2: ${ah === null ? 'unknown' : (ah ? 'artificial head' : 'normal')}`);
+
+        const compressed = parsedData.rds_di ? parsedData.rds_di.compressed : null;
+        $dataDiCompressed.html(compressed ? 'CO' : "<span class='opacity-half'>CO</span>")
+            .attr('aria-label', `DI bit 1: ${compressed === null ? 'unknown' : (compressed ? 'compressed' : 'not compressed')}`);
+
+        const dpty = parsedData.rds_di ? parsedData.rds_di.dynamic_pty : null;
+        $dataDiDpty.html(dpty ? 'DP' : "<span class='opacity-half'>DP</span>")
+            .attr('aria-label', `DI bit 0: ${dpty === null ? 'unknown' : (dpty ? 'dynamic PTY' : 'static')}`);
     }
     
     if (updateCounter % 30 === 0) {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -995,6 +995,13 @@ const updateDataElements = throttle(function(parsedData) {
 
     updateTextIfChanged($dataPty, rdsMode == 'true' ? usa_programmes[parsedData.pty] : europe_programmes[parsedData.pty]);
     updateTextIfChanged($dataPtyn, parsedData.ptyn || '');
+    if (parsedData.ptyn && parsedData.ptyn.trim().length > 0) {
+        $dataPty.hide();
+        $dataPtyn.show();
+    } else {
+        $dataPty.show();
+        $dataPtyn.hide();
+    }
     
     if (parsedData.rds === true) {
         $flagDesktopCointainer.css('background-color', 'var(--color-2-transparent)');

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -890,6 +890,7 @@ const $dataTa = $('.data-ta');
 const $dataMs = $('.data-ms');
 const $flagDesktopCointainer = $('#flags-container-desktop');
 const $dataPty = $('.data-pty');
+const $dataPtyn = $('.data-ptyn');
 
 // Throttling function to limit the frequency of updates
 function throttle(fn, wait) {
@@ -987,8 +988,9 @@ const updateDataElements = throttle(function(parsedData) {
     
     updateHtmlIfChanged($dataRt0, processString(parsedData.rt0, parsedData.rt0_errors));
     updateHtmlIfChanged($dataRt1, processString(parsedData.rt1, parsedData.rt1_errors));
-    
+
     updateTextIfChanged($dataPty, rdsMode == 'true' ? usa_programmes[parsedData.pty] : europe_programmes[parsedData.pty]);
+    updateTextIfChanged($dataPtyn, parsedData.ptyn || '');
     
     if (parsedData.rds === true) {
         $flagDesktopCointainer.css('background-color', 'var(--color-2-transparent)');

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1054,18 +1054,34 @@ const updateDataElements = throttle(function(parsedData) {
                 : "<span class='opacity-full'>M</span><span class='opacity-half'>S</span>"
             )
         );
-        $dataDiStereo.html(parsedData.rds_di && parsedData.rds_di.stereo
-            ? 'ST'
-            : "<span class='opacity-half'>ST</span>");
-        $dataDiAh.html(parsedData.rds_di && parsedData.rds_di.artificial_head
-            ? 'AH'
-            : "<span class='opacity-half'>AH</span>");
-        $dataDiCompressed.html(parsedData.rds_di && parsedData.rds_di.compressed
-            ? 'CO'
-            : "<span class='opacity-half'>CO</span>");
-        $dataDiDpty.html(parsedData.rds_di && parsedData.rds_di.dynamic_pty
-            ? 'DP'
-            : "<span class='opacity-half'>DP</span>");
+        const stereo = parsedData.rds_di ? parsedData.rds_di.stereo : null;
+        const stereoState = stereo === null ? 'unknown' : (stereo ? 'stereo' : 'mono');
+        $dataDiStereo.html(stereo ? 'ST' : "<span class='opacity-half'>ST</span>")
+            .attr('aria-label', `DI bit 3: ${stereoState}`)
+            .attr('data-tooltip', `DI bit 3 \u2013 1: stereo, 0: mono (current: ${stereoState})`);
+
+        const ah = parsedData.rds_di ? parsedData.rds_di.artificial_head : null;
+        const ahState = ah === null ? 'unknown' : (ah ? 'artificial head' : 'normal');
+        $dataDiAh.html(ah ? 'AH' : "<span class='opacity-half'>AH</span>")
+            .attr('aria-label', `DI bit 2: ${ahState}`)
+            .attr('data-tooltip', `DI bit 2 \u2013 1: artificial head, 0: normal (current: ${ahState})`);
+
+        const compressed = parsedData.rds_di ? parsedData.rds_di.compressed : null;
+        const compState = compressed === null ? 'unknown' : (compressed ? 'compressed' : 'not compressed');
+        $dataDiCompressed.html(compressed ? 'CO' : "<span class='opacity-half'>CO</span>")
+            .attr('aria-label', `DI bit 1: ${compState}`)
+            .attr('data-tooltip', `DI bit 1 \u2013 1: compressed, 0: not compressed (current: ${compState})`);
+
+        const dpty = parsedData.rds_di ? parsedData.rds_di.dynamic_pty : null;
+        const dptyState = dpty === null ? 'unknown' : (dpty ? 'dynamic PTY' : 'static');
+        $dataDiDpty.html(dpty ? 'DP' : "<span class='opacity-half'>DP</span>")
+            .attr('aria-label', `DI bit 0: ${dptyState}`)
+            .attr('data-tooltip', `DI bit 0 \u2013 1: dynamic PTY, 0: static (current: ${dptyState})`);
+
+        initTooltips($dataDiStereo);
+        initTooltips($dataDiAh);
+        initTooltips($dataDiCompressed);
+        initTooltips($dataDiDpty);
     }
     
     if (updateCounter % 30 === 0) {


### PR DESCRIPTION
## Summary
- parse PTYN in `datahandler.js`
- expose PTYN value in JSON messages
- show PTYN on the frontend

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847161cb690832f986ee5d221e6b9d4