### PR TITLE
Add decoder identification parsing

### DIFF
--- a/web/index.ejs
+++ b/web/index.ejs
@@ -177,6 +177,10 @@
                   <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
+                <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
+                <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+                <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+                <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
               </h3>
             </div>
           </div>
@@ -336,6 +340,10 @@
             <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
+          <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
+          <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+          <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+          <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
         </h3>
       </div>
     </div>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -888,6 +888,10 @@ const $dataStationContainer = $('#data-station-container');
 const $dataTp = $('.data-tp');
 const $dataTa = $('.data-ta');
 const $dataMs = $('.data-ms');
+const $dataDiStereo = $('.data-di-stereo');
+const $dataDiAh = $('.data-di-ah');
+const $dataDiCompressed = $('.data-di-compressed');
+const $dataDiDpty = $('.data-di-dpty');
 const $flagDesktopCointainer = $('#flags-container-desktop');
 const $dataPty = $('.data-pty');
 const $dataPtyn = $('.data-ptyn');
@@ -1043,6 +1047,18 @@ const updateDataElements = throttle(function(parsedData) {
                 : "<span class='opacity-full'>M</span><span class='opacity-half'>S</span>"
             )
         );
+        $dataDiStereo.html(parsedData.rds_di && parsedData.rds_di.stereo
+            ? 'ST'
+            : "<span class='opacity-half'>ST</span>");
+        $dataDiAh.html(parsedData.rds_di && parsedData.rds_di.artificial_head
+            ? 'AH'
+            : "<span class='opacity-half'>AH</span>");
+        $dataDiCompressed.html(parsedData.rds_di && parsedData.rds_di.compressed
+            ? 'CO'
+            : "<span class='opacity-half'>CO</span>");
+        $dataDiDpty.html(parsedData.rds_di && parsedData.rds_di.dynamic_pty
+            ? 'DP'
+            : "<span class='opacity-half'>DP</span>");
     }
     
     if (updateCounter % 30 === 0) {


### PR DESCRIPTION
## Summary
- parse DI bits from RDS group 0
- expose parsed DI via `rds_di` object
- deep copy initialData to reset DI state
- display DI flags on the web interface

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./server/datahandler.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_68471975b494832fa92432ecfd48843a