### PR TITLE
Add decoder identification parsing

### DIFF
--- a/web/css/breadcrumbs.css
+++ b/web/css/breadcrumbs.css
@@ -182,6 +182,10 @@ table .form-group {
     display: none;
 }
 
+#di-container-phone {
+    display: none;
+}
+
 #login-form {
     padding: 5px;
 }
@@ -214,12 +218,16 @@ h3.settings-heading {
 }
 
 #flags-container-phone,
-#flags-container-desktop {
+#flags-container-desktop,
+#di-container-phone,
+#di-container-desktop {
     position: relative; /* Confine overlay within container which is necessary for iPhones */
 }
 
 #flags-container-phone .overlay,
-#flags-container-desktop .overlay {
+#flags-container-desktop .overlay,
+#di-container-phone .overlay,
+#di-container-desktop .overlay {
     position: absolute;
     top: 0;
     left: 0;
@@ -377,6 +385,12 @@ pre {
         display: none;
     }
     #flags-container-phone {
+        display: block;
+    }
+    #di-container-desktop {
+        display: none;
+    }
+    #di-container-phone {
         display: block;
     }
     #tune-buttons {

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -158,7 +158,7 @@
               </div>
             </div>
 
-            <div id="flags-container-desktop" class="panel-33 user-select-none">
+              <div id="flags-container-desktop" class="panel-33 user-select-none">
               <h2 class="show-phone">
                 <div class="data-pty color-4"></div>
                 <div class="data-ptyn color-4"></div>
@@ -178,10 +178,21 @@
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
               </h3>
+              </div>
             </div>
-          </div>
 
-          <div class="flex-container">
+            <div class="flex-container">
+              <div id="di-container-desktop" class="panel-33 user-select-none">
+                <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+                  <span class="data-di-stereo">ST</span>
+                  <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+                  <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+                  <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+                </h3>
+              </div>
+            </div>
+
+            <div class="flex-container">
             <div class="panel-33 hover-brighten tooltip no-bg-phone" id="pi-code-container" data-tooltip="Clicking on the PI code will show the current station on a map.">
               <h2 class="signal-heading">PI CODE</h2>
               <div class="text-small text-gray highest-signal-container">
@@ -337,6 +348,16 @@
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
         </h3>
+      </div>
+      <div class="flex-container">
+        <div id="di-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
+          <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+            <span class="data-di-stereo">ST</span>
+            <span style="margin-left: 15px;" class="data-di-ah">AH</span>
+            <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
+            <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+          </h3>
+        </div>
       </div>
     </div>
 

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -888,6 +888,10 @@ const $dataStationContainer = $('#data-station-container');
 const $dataTp = $('.data-tp');
 const $dataTa = $('.data-ta');
 const $dataMs = $('.data-ms');
+const $dataDiStereo = $('.data-di-stereo');
+const $dataDiAh = $('.data-di-ah');
+const $dataDiCompressed = $('.data-di-compressed');
+const $dataDiDpty = $('.data-di-dpty');
 const $flagDesktopCointainer = $('#flags-container-desktop');
 const $dataPty = $('.data-pty');
 const $dataPtyn = $('.data-ptyn');
@@ -1043,6 +1047,18 @@ const updateDataElements = throttle(function(parsedData) {
                 : "<span class='opacity-full'>M</span><span class='opacity-half'>S</span>"
             )
         );
+        $dataDiStereo.html(parsedData.rds_di && parsedData.rds_di.stereo
+            ? 'ST'
+            : "<span class='opacity-half'>ST</span>");
+        $dataDiAh.html(parsedData.rds_di && parsedData.rds_di.artificial_head
+            ? 'AH'
+            : "<span class='opacity-half'>AH</span>");
+        $dataDiCompressed.html(parsedData.rds_di && parsedData.rds_di.compressed
+            ? 'CO'
+            : "<span class='opacity-half'>CO</span>");
+        $dataDiDpty.html(parsedData.rds_di && parsedData.rds_di.dynamic_pty
+            ? 'DP'
+            : "<span class='opacity-half'>DP</span>");
     }
     
     if (updateCounter % 30 === 0) {


### PR DESCRIPTION
## Summary
- parse DI bits from RDS group 0
- expose parsed DI via `rds_di` object
- deep copy initialData to reset DI state
- display DI flags on the web interface
- keep stereo indicator and add dedicated DI flag boxes
- fix layout so DI boxes are in their own rows

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./server/datahandler.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_68471975b494832fa92432ecfd48843a