### PR TITLE
Fix DI layout and PTYN display

### DIFF
--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -412,12 +412,14 @@ function handleData(wss, receivedData, rdsWss) {
 
         const blockB = parseInt(modifiedData.slice(4, 8), 16);
         const groupType = (blockB >> 12) & 0xf;
-        if (groupType === 0) {
+        const versionCode = (blockB >> 11) & 0x1;
+        if (groupType === 0 && versionCode === 0) {
           const diValue = (blockB >> 2) & 0x1;
           const diIndex = blockB & 0x3;
 
           switch (diIndex) {
             case 0:
+              // DI bit 0: 0 = stereo, 1 = mono
               dataToSend.rds_di.stereo = diValue === 0;
               break;
             case 1:

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -161,7 +161,7 @@
               <div id="flags-container-desktop" class="panel-33 user-select-none">
               <h2 class="show-phone">
                 <div class="data-pty color-4"></div>
-                <div class="data-ptyn color-4"></div>
+                <div class="data-ptyn color-4" style="display:none;"></div>
               </h2>
               <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
                 <span class="data-tp">TP</span>
@@ -177,33 +177,13 @@
                   <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
-
-
-                <!-- <span style="margin-left: 15px;" class="data-ms">MS</span>
-                <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
+              </h3>
+              <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
+                <span class="data-di-stereo">ST</span>
                 <span style="margin-left: 15px;" class="data-di-ah">AH</span>
                 <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                <span style="margin-left: 15px;" class="data-di-dpty">DP</span> -->
+                <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
               </h3>
-                            <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
-
-                                                <span class="data-di-stereo">ST</span>
-                  <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-                  <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                  <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-                            </h3>
-              
-            </div>
-            </div>
-
-            <div class="flex-container">
-              <div id="di-container-desktop" class="panel-33 user-select-none">
-                <!-- <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
-                  <span class="data-di-stereo">ST</span>
-                  <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-                  <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                  <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-                </h3> -->
               </div>
             </div>
 
@@ -346,7 +326,7 @@
       <div id="flags-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
         <h2 class="show-phone">
           <div class="data-pty color-4"></div>
-          <div class="data-ptyn color-4"></div>
+          <div class="data-ptyn color-4" style="display:none;"></div>
         </h2>
         <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
           <span class="data-tp">TP</span>
@@ -362,29 +342,13 @@
             <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
-          <span style="margin-left: 15px;" class="data-di-stereo">ST</span>
-          <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-          <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-          <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
         </h3>
-      </div>
-      <div id="di-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
-        <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
+        <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
           <span class="data-di-stereo">ST</span>
           <span style="margin-left: 15px;" class="data-di-ah">AH</span>
           <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
           <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
         </h3>
-      </div>
-      <div class="flex-container">
-        <div id="di-container-phone" class="panel-33 no-bg-phone" style="margin-bottom: 110px !important;">
-          <h3 style="margin-top:0;margin-bottom:0;" class="text-color-default flex-center">
-            <span class="data-di-stereo">ST</span>
-            <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-            <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-            <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
-          </h3>
-        </div>
       </div>
     </div>
 

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -995,6 +995,13 @@ const updateDataElements = throttle(function(parsedData) {
 
     updateTextIfChanged($dataPty, rdsMode == 'true' ? usa_programmes[parsedData.pty] : europe_programmes[parsedData.pty]);
     updateTextIfChanged($dataPtyn, parsedData.ptyn || '');
+    if (parsedData.ptyn && parsedData.ptyn.trim().length > 0) {
+        $dataPty.hide();
+        $dataPtyn.show();
+    } else {
+        $dataPty.show();
+        $dataPtyn.hide();
+    }
     
     if (parsedData.rds === true) {
         $flagDesktopCointainer.css('background-color', 'var(--color-2-transparent)');


### PR DESCRIPTION
## Summary
- show PTYN only when available
- combine DI indicators with other flags

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684729e9c808832f8a49ac7a1ea47026