### PR TITLE
Add tooltips for DI bits

### DIFF
--- a/web/index.ejs
+++ b/web/index.ejs
@@ -179,10 +179,10 @@
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
               </h3>
               <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
-                <span class="data-di-stereo">ST</span>
-                <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-                <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-                <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+                <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono">ST</span>
+                <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal">AH</span>
+                <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed">CO</span>
+                <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static">DP</span>
               </h3>
               </div>
             </div>
@@ -344,10 +344,10 @@
           <span style="margin-left: 15px;" class="data-ms">MS</span>
         </h3>
         <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
-          <span class="data-di-stereo">ST</span>
-          <span style="margin-left: 15px;" class="data-di-ah">AH</span>
-          <span style="margin-left: 15px;" class="data-di-compressed">CO</span>
-          <span style="margin-left: 15px;" class="data-di-dpty">DP</span>
+          <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono">ST</span>
+          <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal">AH</span>
+          <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed">CO</span>
+          <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static">DP</span>
         </h3>
       </div>
     </div>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1054,18 +1054,21 @@ const updateDataElements = throttle(function(parsedData) {
                 : "<span class='opacity-full'>M</span><span class='opacity-half'>S</span>"
             )
         );
-        $dataDiStereo.html(parsedData.rds_di && parsedData.rds_di.stereo
-            ? 'ST'
-            : "<span class='opacity-half'>ST</span>");
-        $dataDiAh.html(parsedData.rds_di && parsedData.rds_di.artificial_head
-            ? 'AH'
-            : "<span class='opacity-half'>AH</span>");
-        $dataDiCompressed.html(parsedData.rds_di && parsedData.rds_di.compressed
-            ? 'CO'
-            : "<span class='opacity-half'>CO</span>");
-        $dataDiDpty.html(parsedData.rds_di && parsedData.rds_di.dynamic_pty
-            ? 'DP'
-            : "<span class='opacity-half'>DP</span>");
+        const stereo = parsedData.rds_di ? parsedData.rds_di.stereo : null;
+        $dataDiStereo.html(stereo ? 'ST' : "<span class='opacity-half'>ST</span>")
+            .attr('aria-label', `DI bit 3: ${stereo === null ? 'unknown' : (stereo ? 'stereo' : 'mono')}`);
+
+        const ah = parsedData.rds_di ? parsedData.rds_di.artificial_head : null;
+        $dataDiAh.html(ah ? 'AH' : "<span class='opacity-half'>AH</span>")
+            .attr('aria-label', `DI bit 2: ${ah === null ? 'unknown' : (ah ? 'artificial head' : 'normal')}`);
+
+        const compressed = parsedData.rds_di ? parsedData.rds_di.compressed : null;
+        $dataDiCompressed.html(compressed ? 'CO' : "<span class='opacity-half'>CO</span>")
+            .attr('aria-label', `DI bit 1: ${compressed === null ? 'unknown' : (compressed ? 'compressed' : 'not compressed')}`);
+
+        const dpty = parsedData.rds_di ? parsedData.rds_di.dynamic_pty : null;
+        $dataDiDpty.html(dpty ? 'DP' : "<span class='opacity-half'>DP</span>")
+            .attr('aria-label', `DI bit 0: ${dpty === null ? 'unknown' : (dpty ? 'dynamic PTY' : 'static')}`);
     }
     
     if (updateCounter % 30 === 0) {


### PR DESCRIPTION
## Summary
- show DI bit explanations in desktop and mobile sections
- update dynamic aria labels for DI info

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847449d41d4832f83c67eb129be559f