### PR TITLE
Fix DI indicator opacity on missing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ FM-DX Webserver is a cross-platform web server designed for FM DXers who want to
 - **FM DXing:** Enhance your FM/AM DXing experience with a user-friendly web interface.
 - **Cross-Platform:** You can run this on both Windows and Linux servers along with xdrd.
 - **Low-latency streaming**: Built in directly into the webserver, no external apps needed for users
+- **DI bit indicators**: Stereo, Artificial Head, Compression and Dynamic PTY labels only dim when the receiver doesn't provide DI data
 
 ## Features to be added
 Check [here](https://trello.com/b/OAKo7n0Q/fm-dx-webserver) for an up to date task list

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -230,10 +230,10 @@ var dataToSend = {
   rt1: '',
   rt_flag: '',
   rds_di: {
-    stereo: false
-    compressed: false
-    artificial_head: false
-    dynamic_pty: false
+    stereo: false,
+    compressed: false,
+    artificial_head: false,
+    dynamic_pty: false,
   },
   ims: 0,
   eq: 0,

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -230,10 +230,10 @@ var dataToSend = {
   rt1: '',
   rt_flag: '',
   rds_di: {
-    stereo: null,
-    compressed: null,
-    artificial_head: null,
-    dynamic_pty: null,
+    stereo: false
+    compressed: false
+    artificial_head: false
+    dynamic_pty: false
   },
   ims: 0,
   eq: 0,

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -179,10 +179,10 @@
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
               </h3>
               <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
-                <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono"><span class="opacity-half">ST</span></span>
-                <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal"><span class="opacity-half">AH</span></span>
-                <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed"><span class="opacity-half">CO</span></span>
-                <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static"><span class="opacity-half">DP</span></span>
+                <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono">ST</span>
+                <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal">AH</span>
+                <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed">CO</span>
+                <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static">DP</span>
               </h3>
               </div>
             </div>
@@ -344,10 +344,10 @@
           <span style="margin-left: 15px;" class="data-ms">MS</span>
         </h3>
         <h3 style="margin-top:4px;margin-bottom:0;" class="text-color-default flex-center">
-          <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono"><span class="opacity-half">ST</span></span>
-          <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal"><span class="opacity-half">AH</span></span>
-          <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed"><span class="opacity-half">CO</span></span>
-          <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static"><span class="opacity-half">DP</span></span>
+          <span class="data-di-stereo tooltip" aria-label="DI bit 3: stereo status" data-tooltip="DI bit 3 – 1: stereo, 0: mono">ST</span>
+          <span style="margin-left: 15px;" class="data-di-ah tooltip" aria-label="DI bit 2: artificial head" data-tooltip="DI bit 2 – 1: artificial head, 0: normal">AH</span>
+          <span style="margin-left: 15px;" class="data-di-compressed tooltip" aria-label="DI bit 1: compression" data-tooltip="DI bit 1 – 1: compressed, 0: not compressed">CO</span>
+          <span style="margin-left: 15px;" class="data-di-dpty tooltip" aria-label="DI bit 0: dynamic PTY" data-tooltip="DI bit 0 – 1: dynamic PTY, 0: static">DP</span>
         </h3>
       </div>
     </div>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1056,27 +1056,31 @@ const updateDataElements = throttle(function(parsedData) {
         );
         const stereo = parsedData.rds_di ? parsedData.rds_di.stereo : null;
         const stereoState = stereo === null ? 'unknown' : (stereo ? 'stereo' : 'mono');
-        $dataDiStereo.html(stereo ? 'ST' : "<span class='opacity-half'>ST</span>")
+        $dataDiStereo.text('ST')
             .attr('aria-label', `DI bit 3: ${stereoState}`)
-            .attr('data-tooltip', `DI bit 3 \u2013 1: stereo, 0: mono (current: ${stereoState})`);
+            .attr('data-tooltip', `DI bit 3 \u2013 1: stereo, 0: mono (current: ${stereoState})`)
+            .toggleClass('opacity-half', stereo === null);
 
         const ah = parsedData.rds_di ? parsedData.rds_di.artificial_head : null;
         const ahState = ah === null ? 'unknown' : (ah ? 'artificial head' : 'normal');
-        $dataDiAh.html(ah ? 'AH' : "<span class='opacity-half'>AH</span>")
+        $dataDiAh.text('AH')
             .attr('aria-label', `DI bit 2: ${ahState}`)
-            .attr('data-tooltip', `DI bit 2 \u2013 1: artificial head, 0: normal (current: ${ahState})`);
+            .attr('data-tooltip', `DI bit 2 \u2013 1: artificial head, 0: normal (current: ${ahState})`)
+            .toggleClass('opacity-half', ah === null);
 
         const compressed = parsedData.rds_di ? parsedData.rds_di.compressed : null;
         const compState = compressed === null ? 'unknown' : (compressed ? 'compressed' : 'not compressed');
-        $dataDiCompressed.html(compressed ? 'CO' : "<span class='opacity-half'>CO</span>")
+        $dataDiCompressed.text('CO')
             .attr('aria-label', `DI bit 1: ${compState}`)
-            .attr('data-tooltip', `DI bit 1 \u2013 1: compressed, 0: not compressed (current: ${compState})`);
+            .attr('data-tooltip', `DI bit 1 \u2013 1: compressed, 0: not compressed (current: ${compState})`)
+            .toggleClass('opacity-half', compressed === null);
 
         const dpty = parsedData.rds_di ? parsedData.rds_di.dynamic_pty : null;
         const dptyState = dpty === null ? 'unknown' : (dpty ? 'dynamic PTY' : 'static');
-        $dataDiDpty.html(dpty ? 'DP' : "<span class='opacity-half'>DP</span>")
+        $dataDiDpty.text('DP')
             .attr('aria-label', `DI bit 0: ${dptyState}`)
-            .attr('data-tooltip', `DI bit 0 \u2013 1: dynamic PTY, 0: static (current: ${dptyState})`);
+            .attr('data-tooltip', `DI bit 0 \u2013 1: dynamic PTY, 0: static (current: ${dptyState})`)
+            .toggleClass('opacity-half', dpty === null);
 
         initTooltips($dataDiStereo);
         initTooltips($dataDiAh);


### PR DESCRIPTION
## Summary
- ensure DI indicators only dim when data is missing
- remove default opacity from DI labels in the page
- document DI indicator behaviour

## Testing
- `npm run webserver` *(fails to fetch transmitter database but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_686c103af07c832fb2256b3d666de718