### PR TITLE
feat: add RDS DI and PTYN support

### DIFF
--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -409,8 +409,9 @@ function handleData(wss, receivedData, rdsWss) {
         const blockB = parseInt(modifiedData.slice(4, 8), 16);
         const groupType = (blockB >> 12) & 0xF;
         if (groupType === 0 && (errors & 0x30) === 0) {
-          const diIndex = (blockB >> 1) & 0x3;
-          const diVal = blockB & 0x1;
+          // Bits 0-1 select the DI flag index, bit 2 carries the flag's value
+          const diIndex = blockB & 0x3;
+          const diVal = (blockB >> 2) & 0x1;
           dataToSend.di = (dataToSend.di & ~(1 << diIndex)) | (diVal << diIndex);
         }
 

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -409,9 +409,9 @@ function handleData(wss, receivedData, rdsWss) {
         const blockB = parseInt(modifiedData.slice(4, 8), 16);
         const groupType = (blockB >> 12) & 0xF;
         if (groupType === 0 && (errors & 0x30) === 0) {
-          // Bits 0-1 select the DI flag index, bit 2 carries the flag's value
-          const diIndex = blockB & 0x3;
-          const diVal = (blockB >> 2) & 0x1;
+          // Bits 1-2 select the DI flag index; bit 3 holds the flag value (bit 0 = MS)
+          const diIndex = (blockB >> 1) & 0x3;
+          const diVal = (blockB >> 3) & 0x1;
           dataToSend.di = (dataToSend.di & ~(1 << diIndex)) | (diVal << diIndex);
         }
 

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -408,8 +408,8 @@ function handleData(wss, receivedData, rdsWss) {
         const blockB = parseInt(modifiedData.slice(4, 8), 16);
         const groupType = (blockB >> 12) & 0xF;
         if (groupType === 0) {
-          const diVal = (blockB >> 2) & 0x1;
-          const diIndex = blockB & 0x3;
+          const diIndex = (blockB >> 1) & 0x3;
+          const diVal = blockB & 0x1;
           dataToSend.di = (dataToSend.di & ~(1 << diIndex)) | (diVal << diIndex);
         }
 

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -409,9 +409,9 @@ function handleData(wss, receivedData, rdsWss) {
         const blockB = parseInt(modifiedData.slice(4, 8), 16);
         const groupType = (blockB >> 12) & 0xF;
         if (groupType === 0 && (errors & 0x30) === 0) {
-          // Bits 1-2 select the DI flag index; bit 3 holds the flag value (bit 0 = MS)
+          // Bits 1-2 select the DI flag index; bit 0 holds the flag value
           const diIndex = (blockB >> 1) & 0x3;
-          const diVal = (blockB >> 3) & 0x1;
+          const diVal = blockB & 0x1;
           dataToSend.di = (dataToSend.di & ~(1 << diIndex)) | (diVal << diIndex);
         }
 

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -409,9 +409,9 @@ function handleData(wss, receivedData, rdsWss) {
         const blockB = parseInt(modifiedData.slice(4, 8), 16);
         const groupType = (blockB >> 12) & 0xF;
         if (groupType === 0 && (errors & 0x30) === 0) {
-          // Bits 1-2 select the DI flag index; bit 0 holds the flag value
-          const diIndex = (blockB >> 1) & 0x3;
-          const diVal = blockB & 0x1;
+          // Bits 0-1 select the DI flag index; bit 2 holds the flag value
+          const diIndex = blockB & 0x3;
+          const diVal = (blockB >> 2) & 0x1;
           dataToSend.di = (dataToSend.di & ~(1 << diIndex)) | (diVal << diIndex);
         }
 

--- a/server/datahandler.js
+++ b/server/datahandler.js
@@ -410,7 +410,9 @@ function handleData(wss, receivedData, rdsWss) {
         if (groupType === 0) {
           const diIndex = (blockB >> 1) & 0x3;
           const diVal = blockB & 0x1;
-          dataToSend.di = (dataToSend.di & ~(1 << diIndex)) | (diVal << diIndex);
+          const bitMap = [3, 2, 1, 0];
+          const pos = bitMap[diIndex];
+          dataToSend.di = (dataToSend.di & ~(1 << pos)) | (diVal << pos);
         }
 
         rdsparser.parse_string(rds, modifiedData);

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -176,7 +176,7 @@
                   <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
-                <span style="margin-left: 15px;" class="data-di">DI</span>
+                <span style="margin-left: 15px;" class="data-di tooltip" data-tooltip="" aria-label="Decoder Information">DI</span>
               </h3>
             </div>
           </div>
@@ -338,7 +338,7 @@
             <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
-          <span style="margin-left: 15px;" class="data-di">DI</span>
+          <span style="margin-left: 15px;" class="data-di tooltip" data-tooltip="" aria-label="Decoder Information">DI</span>
         </h3>
       </div>
     </div>

--- a/web/index.ejs
+++ b/web/index.ejs
@@ -176,6 +176,7 @@
                   <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
                 </span>
                 <span style="margin-left: 15px;" class="data-ms">MS</span>
+                <span style="margin-left: 15px;" class="data-di">DI</span>
               </h3>
             </div>
           </div>
@@ -280,6 +281,9 @@
               </div>
             <div class="panel-75 hover-brighten no-bg-phone" id="rt-container" style="height: 100px;">
               <h2 style="margin-top: 4px;">RADIOTEXT</h2>
+              <div id="data-ptyn">
+                <span></span>
+              </div>
               <div id="data-rt0">
                 <span></span>
               </div>
@@ -334,6 +338,7 @@
             <span class="overlay tooltip" data-tooltip="Stereo / Mono toggle. <br><strong>Click to toggle."></span>
           </span>
           <span style="margin-left: 15px;" class="data-ms">MS</span>
+          <span style="margin-left: 15px;" class="data-di">DI</span>
         </h3>
       </div>
     </div>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1053,10 +1053,10 @@ const updateDataElements = throttle(function(parsedData) {
             )
         );
         const diDesc = [
-            `Stereo/Mono: ${(parsedData.di & 0x1) ? 'Mono' : 'Stereo'}`,
-            `Artificial Head: ${(parsedData.di & 0x2) ? 'Yes' : 'No'}`,
-            `Compressed: ${(parsedData.di & 0x4) ? 'Yes' : 'No'}`,
-            `Dynamic PTY: ${(parsedData.di & 0x8) ? 'Yes' : 'No'}`
+            `Stereo/Mono: ${(parsedData.di & 0x8) ? 'Mono' : 'Stereo'}`,
+            `Artificial Head: ${(parsedData.di & 0x4) ? 'Yes' : 'No'}`,
+            `Compressed: ${(parsedData.di & 0x2) ? 'Yes' : 'No'}`,
+            `Dynamic PTY: ${(parsedData.di & 0x1) ? 'Yes' : 'No'}`
         ].join('<br>');
         $dataDi
             .html((parsedData.di & 0xF) === 0 ? "<span class='opacity-half'>DI</span>" : "DI")

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1052,7 +1052,16 @@ const updateDataElements = throttle(function(parsedData) {
                 : "<span class='opacity-full'>M</span><span class='opacity-half'>S</span>"
             )
         );
-        $dataDi.html((parsedData.di & 0x8) === 0 ? "<span class='opacity-half'>DI</span>" : "DI");
+        const diDesc = [
+            `Stereo/Mono: ${(parsedData.di & 0x1) ? 'Mono' : 'Stereo'}`,
+            `Artificial Head: ${(parsedData.di & 0x2) ? 'Yes' : 'No'}`,
+            `Compressed: ${(parsedData.di & 0x4) ? 'Yes' : 'No'}`,
+            `Dynamic PTY: ${(parsedData.di & 0x8) ? 'Yes' : 'No'}`
+        ].join('<br>');
+        $dataDi
+            .html((parsedData.di & 0x8) === 0 ? "<span class='opacity-half'>DI</span>" : "DI")
+            .attr('data-tooltip', diDesc)
+            .attr('aria-label', diDesc.replace(/<br>/g, ', '));
     }
     
     if (updateCounter % 30 === 0) {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1053,7 +1053,7 @@ const updateDataElements = throttle(function(parsedData) {
             )
         );
         const diDesc = [
-            `Stereo/Mono: ${(parsedData.di & 0x8) ? 'Mono' : 'Stereo'}`,
+            `Has Stereo: ${(parsedData.di & 0x8) ? 'Yes' : 'No'}`,
             `Artificial Head: ${(parsedData.di & 0x4) ? 'Yes' : 'No'}`,
             `Compressed: ${(parsedData.di & 0x2) ? 'Yes' : 'No'}`,
             `Dynamic PTY: ${(parsedData.di & 0x1) ? 'Yes' : 'No'}`

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -897,6 +897,8 @@ const $dataTa = $('.data-ta');
 const $dataMs = $('.data-ms');
 const $flagDesktopCointainer = $('#flags-container-desktop');
 const $dataPty = $('.data-pty');
+const $dataPtyn = $('#data-ptyn span');
+const $dataDi = $('.data-di');
 
 // Throttling function to limit the frequency of updates
 function throttle(fn, wait) {
@@ -994,7 +996,8 @@ const updateDataElements = throttle(function(parsedData) {
     
     updateHtmlIfChanged($dataRt0, processString(parsedData.rt0, parsedData.rt0_errors));
     updateHtmlIfChanged($dataRt1, processString(parsedData.rt1, parsedData.rt1_errors));
-    
+    updateHtmlIfChanged($dataPtyn, processString(parsedData.ptyn, parsedData.ptyn_errors));
+
     updateTextIfChanged($dataPty, rdsMode == 'true' ? usa_programmes[parsedData.pty] : europe_programmes[parsedData.pty]);
     
     if (parsedData.rds === true) {
@@ -1049,6 +1052,7 @@ const updateDataElements = throttle(function(parsedData) {
                 : "<span class='opacity-full'>M</span><span class='opacity-half'>S</span>"
             )
         );
+        $dataDi.html((parsedData.di & 0x8) === 0 ? "<span class='opacity-half'>DI</span>" : "DI");
     }
     
     if (updateCounter % 30 === 0) {

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1059,7 +1059,7 @@ const updateDataElements = throttle(function(parsedData) {
             `Dynamic PTY: ${(parsedData.di & 0x8) ? 'Yes' : 'No'}`
         ].join('<br>');
         $dataDi
-            .html((parsedData.di & 0x8) === 0 ? "<span class='opacity-half'>DI</span>" : "DI")
+            .html((parsedData.di & 0xF) === 0 ? "<span class='opacity-half'>DI</span>" : "DI")
             .attr('data-tooltip', diDesc)
             .data('tooltip', diDesc)
             .attr('aria-label', diDesc.replace(/<br>/g, ', '));

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1061,6 +1061,7 @@ const updateDataElements = throttle(function(parsedData) {
         $dataDi
             .html((parsedData.di & 0x8) === 0 ? "<span class='opacity-half'>DI</span>" : "DI")
             .attr('data-tooltip', diDesc)
+            .data('tooltip', diDesc)
             .attr('aria-label', diDesc.replace(/<br>/g, ', '));
     }
     


### PR DESCRIPTION
## Summary
- capture RDS Program Type Name (PTYN) and decoder information bits on the server
- expose DI and PTYN through websocket data and display them on the web UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check server/datahandler.js`
- `node --check web/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4543f8538832fb106e58e75bbbfeb